### PR TITLE
Move to using DescribableModel and friends.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,23 +43,23 @@
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean</artifactId>
-            <version>1.0.0-b12-SNAPSHOT</version>
+            <version>1.0.0-b12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-rest</artifactId>
-            <version>1.0.0-b12-SNAPSHOT</version>
+            <version>1.0.0-b12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.1</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.8</version>
+            <version>2.23</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/blueocean/rest/pipeline/editor/PipelineStepMetadata.java
+++ b/src/main/java/io/blueocean/rest/pipeline/editor/PipelineStepMetadata.java
@@ -46,7 +46,13 @@ public interface PipelineStepMetadata {
      */
     @Exported
     public String getSnippetizerUrl();
-    
+
+    /**
+     * Whether this step has one and only one parameter and it is required.
+     */
+    @Exported
+    public boolean getHasSingleRequiredParameter();
+
     /**
      * Properties the steps supports
      */


### PR DESCRIPTION
Everything we need is available either from the StepDescriptor or the
DescribableModel (and its DescribableParameters) directly - no need to
go through methods looking for DataBoundSetters etc.